### PR TITLE
added report creative commons license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,37 @@
+# License
+
+## Analysis report
+
+Copyright (c) 2025
+
+
+## You are free to:
+
+- **Share** — copy and redistribute the material in any medium or format
+- **Adapt** — remix, transform, and build upon the material
+
+The licensor cannot revoke these freedoms as long as you follow the license terms.
+
+## Under the following terms:
+
+- **Attribution** — You must give appropriate credit (mentioning that your work is derived from work that is Copyright © Amar Gill, Ruth Yankson, Limor Winter, Claire Saunders), provide a link to the license, and indicate if changes were made. You may do so in any reasonable manner, but not in any way that suggests the licensor endorses you or your use.
+- **NonCommercial** — You may not use the material for commercial purposes.
+- **ShareAlike** — If you remix, transform, or build upon the material, you must distribute your contributions under the same license as the original.
+
+**No additional restrictions** — You may not apply legal terms or technological measures that legally restrict others from doing anything the license permits.
+
+## Notices:
+
+You do not have to comply with the license for elements of the material in the public domain or where your use is permitted by an applicable exception or limitation.
+
+No warranties are given. The license may not give you all of the permissions necessary for your intended use. For example, other rights such as publicity, privacy, or moral rights may limit how you use the material.
+
+## Software code
+
 MIT License
 
 Copyright (c) DSCI 522 (2025)
+
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
 in the Software without restriction, including without limitation the rights


### PR DESCRIPTION
The milestone one outline states: We will learn more about licenses later in the course, and for now we recommend using an [MIT license](https://opensource.org/licenses/MIT) for the project code and a Creative Commons [Attribution-NonCommercial-NoDerivatives 4.0 International (CC BY-NC-ND 4.0)](https://creativecommons.org/licenses/by-nc-nd/4.0/) license for the project report. I have added the second portion with the Creative Commons license for the report. 