### PR TITLE
Anomalous correlations

### DIFF
--- a/notebooks/poisonous_mushroom_classifier.qmd
+++ b/notebooks/poisonous_mushroom_classifier.qmd
@@ -29,6 +29,7 @@ from sklearn.pipeline import make_pipeline
 from sklearn.svm import SVC
 from sklearn.metrics import confusion_matrix, ConfusionMatrixDisplay
 from scipy.stats import chi2_contingency
+import itertools
 ```
 
 # Summary
@@ -458,8 +459,11 @@ train_df = X_train.copy()
 train_df['is_poisonous'] = y_train
 ```
 
+## Data Validation Check: Any Anomalous Correlation Between Features and/or Target? 
+
 ```{python}
- # Data Validation Check: any Anomalous correlation between features or between features and the target? 
+#| label: fig-corr-heatmap
+#| fig-cap: "Correlation heatmap (Cramér's V) for all feature and feature-target pairs in the training data."
 
 # create list of all pairwise feature and feature-target combinations 
 train_df_cols = list(train_df.columns)
@@ -496,19 +500,29 @@ cramers_long = cramers_matrix.reset_index().melt(id_vars='index')
 cramers_long.columns = ['feature_1', 'feature_2', 'cramers_v']
 
 correlation_heatmap = alt.Chart(cramers_long).mark_rect().encode(
-    x=alt.X('feature_1:N', sort=feature_cols),
-    y=alt.Y('feature_2:N', sort=feature_cols),
-    color=alt.Color('cramers_v:Q', scale=alt.Scale(domain=[0,1], scheme='purpleorange'))
-)
+    x=alt.X('feature_1:N', 
+        sort=feature_cols,
+        title='Feature 1'),
+    y=alt.Y('feature_2:N',
+         sort=feature_cols,
+         title="Feature 2"),
+    color=alt.Color('cramers_v:Q', 
+        scale=alt.Scale(domain=[0,1], scheme='purpleorange'),
+        title="Cramer's V"
+        )
+    ).properties(
+        width=300,
+        height=300
+       )
 
 correlation_heatmap
 ```
 
 ## Summary of Anomalous Correlation Between Features:
-There is a high correlation between the feature gill_attachment and the three features stalk_color_above_ring, stalk_color_below_ring, and veil_color. I expect this is a feature of the dataset because it includes a high number of observations (5686 in our training data) and only 23 species, so there are many repeated instances of each species. If a particular species has fixed color and gill attachment characteristics than it is expected that we would find a high correlation between these features. It is not likely to be a sign of data leakage, but does suggest that there are weaknesses in the biological representativeness of the dataset. Therefore, the dataset may not be the strongest choice for generalizing predictions about the poisonousness of mushrooms across the full Agaricus and Lepiota (Agaricaceae) family, since it may not capture the true diversity and independence of these features found in nature.
+@fig-corr-heatmap shows a high correlation between the feature gill_attachment and the three features stalk_color_above_ring, stalk_color_below_ring, and veil_color. I expect this is a feature of the dataset because it includes a high number of observations (5686 in our training data) and only 23 species, so there are many repeated instances of each species. If a particular species has fixed color and gill attachment characteristics than it is expected that we would find a high correlation between these features. It is not likely to be a sign of data leakage, but does suggest that there are weaknesses in the biological representativeness of the dataset. Therefore, the dataset may not be the strongest choice for generalizing predictions about the poisonousness of mushrooms across the full Agaricus and Lepiota (Agaricaceae) family, since it may not capture the true diversity and independence of these features found in nature.
 
 ## Summary of Anomalous Correlation Between Feature "Odor" and Target: 
-The above heatmap shows a high correlation between the feature "odor" and the target, and a moderately high correlation between "spore_print_color" and the target. However, the dataset we are using includes background information on the logical rules discovered by prior researchers Duch, Adamczak, and Grabczewski (1996), and they found that "odor" is often the first split for identifying poisonous mushrooms, and "spore_print_color" is often the second. Hence both of these features are expected to be strong predictors of the target and the seeming anomalous correlation is simply an accurate reflection of biological reality as captured by the dataset, and not likely to be a sign of data leakage in this case. 
+@fig-corr-heatmap shows a high correlation between the feature "odor" and the target, and a moderately high correlation between "spore_print_color" and the target. However, the dataset we are using includes background information on the logical rules discovered by prior researchers Duch, Adamczak, and Grabczewski (1996), and they found that "odor" is often the first split for identifying poisonous mushrooms, and "spore_print_color" is often the second. Hence both of these features are expected to be strong predictors of the target and the seeming anomalous correlation is simply an accurate reflection of biological reality as captured by the dataset, and not likely to be a sign of data leakage in this case. 
 
 ## Model 
 


### PR DESCRIPTION
This pull request contains my code to check these two items on the data validation checklist: 
1) No anomalous correlations between features/explanatory variables
2) No anomalous correlations between target/response variable and features/explanatory variables

**Please note** when working on this I noticed that we accidentally had the "class" column in addition to the "is_poisonous" column but they are both the target column (the "is_poisonous" column is the "class" column transformed into binary numbers rather than "e" and "p" for edible and poisonous - and we actually trained our model with "class" as a feature. As such, I went through and made adjustments to code as needed to remove the extra column and ensure our training data didn't include the target! Please review my adjustments to make sure I corrected the error properly. 

For this data validation checklist item, to check the anomalous correlations I created a function to generate cramers_v correlation values for ALL pairwise combinations of features with features and features with the target, and then displayed the correlation as a heatmap and wrote an analysis of the strongly correlated results - I believe none are problematic for our model. 