### PR TITLE
Target distribution check & Golden Rule Fix

### DIFF
--- a/notebooks/poisonous_mushroom_classifier.qmd
+++ b/notebooks/poisonous_mushroom_classifier.qmd
@@ -98,7 +98,9 @@ df = pd.read_csv("../data/raw/agaricus-lepiota.data", names=dataset_col_names)
 actual_distribution = df['class'].value_counts(normalize=True).round(3).to_dict()
 # as per dataset documentation, expected proportions for each target
 expected_distribution = {'e': 0.518, 'p':0.482}
-assert actual_distribution == expected_distribution, f"{actual_distribution} != {expected_distribution}"
+for prop in expected_distribution:
+    assert np.isclose(actual_distribution[prop], expected_distribution[prop], atol=0.01), \
+        f"Class {k}: {actual_distribution[prop]} != {expected_distribution[prop]}"
 
 # Changing the target to numeric values: poisonous=1, edible=0
 df["is_poisonous"] = df["class"].map({"p": 1, "e": 0})
@@ -165,6 +167,11 @@ A random state of `123` will ensure reproducibility when ran by subsequent users
 X_train, X_test, y_train, y_test = train_test_split(
     df.loc[:,'cap_shape':'habitat'], df['is_poisonous'], test_size=0.3, random_state=123
 )
+
+# Data Validation Check: Target distribution is as expected, ie. representative in Train and Test Set
+print("Overall proportion poisonous:", df['is_poisonous'].mean())
+print("Train set proportion poisonous:", y_train.mean())
+print("Test set proportion poisonous:", y_test.mean())
 
 ```
 
@@ -516,7 +523,7 @@ correlation_heatmap
 Before we continue, we must preprocess our data such that the features work with our models. Since all of our features are strings, we can opt to use one-hot encoding for them all. 
 
 ```{python}
-preprocessor = OneHotEncoder(handle_unkown="ignore")
+preprocessor = OneHotEncoder(handle_unknown="ignore")
 
 ```
 


### PR DESCRIPTION
This PR builds on my previous PR - anomalous_correlations. In this PR I went through and attempted to fix the golden rule error that Sky mentioned in class today, and that Ruth aptly pointed out in discussion on the anomalous_correlations branch. Namely, moving our test-train split up so that it is before certain aspects of our EDA. I tried my best to identify where the split should fall, and then went through and debugged things as needed to make sure everything ran from X_train and not df after the split. It was a lot of fiddling with things to get it all laid out and working so  thank you in advance for your patience in reviewing all of the adjustments. Please look closely to make sure the changes are okay - I tried re-running from start to finish and rendering and it is working for me so I hope the adjustments work. 

Additionally, this PR includes a Data Validation Check to ensure that the target variable distribution matches the expected distribution reported in the dataset documentation. I used an assert statement to confirm that the proportions of target values in the DataFrame we read in correspond to the published proportions. I placed this check before performing the train-test split, since I believe the goal is to verify that the entire raw dataset is structured and balanced as expected prior to any modelling or preprocessing. This ensures we are starting with the same data quality as described in the source, and helps catch any issues during data ingestion. 

Thanks for your review! 